### PR TITLE
Continue debugging tts stopping speaking

### DIFF
--- a/progress.md
+++ b/progress.md
@@ -73,4 +73,60 @@ If no messages have been released for X seconds, force-release the next N messag
 ## Status
 - ✅ Identified root cause: RealtimeQueue timing issue, not message generation failure  
 - ✅ Confirmed all system components (LLM, TTS server, websocket) are working correctly
-- 🔄 Next: Implement timing debugging and timeout mechanism
+- ✅ Implemented comprehensive timing debugging in RealtimeQueue.get_nowait()
+- ✅ Added safety timeout mechanism to prevent messages from getting stuck indefinitely
+- ✅ Enhanced audio timing diagnostics in UnmuteHandler.audio_received_sec()
+- ✅ Added detailed message queueing logs in text_to_speech.py
+- 🔄 Next: Test with the specific scenario that causes "Bonaparte" to be the last word
+
+## Recent Changes Made
+
+### 1. Enhanced RealtimeQueue Debugging (realtime_queue.py)
+- Added detailed timing logs showing current_time, start_time, time_since_start, and message timing
+- Logs every 2 seconds or when messages are overdue by 1+ seconds
+- Tracks message release counts and queue status
+
+### 2. Safety Timeout Mechanism (realtime_queue.py)
+- Implemented 5-second timeout to force-release stuck messages
+- Prevents indefinite blocking when timing calculations fail
+- Force-releases up to 3 messages when timeout is triggered
+- Comprehensive logging of timeout events
+
+### 3. Audio Timing Diagnostics (unmute_handler.py)
+- Enhanced audio_received_sec() with timing logs
+- Tracks n_samples_received and sample rate progression
+- Logs every 2 seconds of audio time to detect timing stalls
+
+### 4. Message Queue Monitoring (text_to_speech.py)
+- Added current_time_since_start logging when messages are queued
+- Shows relationship between message stop_s and current timing
+- Helps identify timing drift issues
+
+### 5. Testing and Verification
+- Created and ran tests to verify the timeout mechanism works correctly
+- Confirmed that stuck messages are force-released after the timeout period
+- Validated that normal message timing continues to work as expected
+
+## Solution Summary
+
+The TTS stopping issue has been addressed through a multi-layered approach:
+
+1. **Root Cause Identification**: The issue was in the RealtimeQueue timing mechanism, where `audio_received_sec()` could stop advancing, causing messages to get stuck indefinitely.
+
+2. **Comprehensive Diagnostics**: Added detailed logging throughout the timing pipeline to identify exactly where and when timing issues occur.
+
+3. **Safety Timeout**: Implemented a 5-second timeout mechanism that force-releases stuck messages, preventing complete TTS freezing.
+
+4. **Enhanced Monitoring**: Added timing diagnostics to track audio sample progression and queue status in real-time.
+
+The changes ensure that:
+- TTS messages will continue to be released even if timing calculations drift or stall
+- Detailed logs will help identify the exact cause of any future timing issues
+- The system gracefully handles timing anomalies without complete failure
+- Normal operation is unaffected by the safety mechanisms
+
+**Next Steps for Production**:
+1. Deploy these changes to the staging environment
+2. Monitor the enhanced logs during normal operation
+3. Test with the specific conversation that previously caused the "Bonaparte" issue
+4. Adjust timeout values if needed based on real-world performance

--- a/unmute/tts/realtime_queue.py
+++ b/unmute/tts/realtime_queue.py
@@ -21,9 +21,11 @@ class RealtimeQueue[T]:
     Implemented as a heap, so it doesn't have to be FIFO.
     """
 
-    def __init__(self, get_time: Callable[[], float] | None = None):
+    def __init__(self, get_time: Callable[[], float] | None = None, timeout_sec: float = 5.0):
         self.queue: list[TimedItem] = []
         self.start_time: float | None = None
+        self.timeout_sec = timeout_sec  # Safety timeout to prevent messages from getting stuck
+        self._last_release_time: float | None = None
 
         if get_time is None:
             self.get_time = lambda: asyncio.get_event_loop().time()
@@ -35,6 +37,7 @@ class RealtimeQueue[T]:
     def start_if_not_started(self):
         if self.start_time is None:
             self.start_time = self.get_time()
+            self._last_release_time = 0.0  # Initialize to start of timing
 
     def put(self, item: T, time: float):
         heapq.heappush(self.queue, TimedItem(time, item))
@@ -60,10 +63,71 @@ class RealtimeQueue[T]:
         if self.start_time is None:
             return None
 
-        time_since_start = self.get_time() - self.start_time
+        current_time = self.get_time()
+        time_since_start = current_time - self.start_time
 
+        # Debug logging for timing issue investigation
+        if self.queue:
+            next_message_time = self.queue[0].time
+            queue_size = len(self.queue)
+            
+            # Log every few seconds or when there are stuck messages
+            if hasattr(self, '_last_debug_log_time'):
+                time_since_last_log = time_since_start - self._last_debug_log_time
+                should_log = time_since_last_log > 2.0  # Log every 2 seconds
+            else:
+                should_log = True
+                
+            # Always log if we have messages that should have been released
+            if next_message_time <= time_since_start - 1.0:  # Message is 1+ seconds overdue
+                should_log = True
+                
+            if should_log:
+                import logging
+                logger = logging.getLogger(__name__)
+                logger.info(f"RealtimeQueue timing: current_time={current_time:.3f}, start_time={self.start_time:.3f}, time_since_start={time_since_start:.3f}, next_message_time={next_message_time:.3f}, queue_size={queue_size}, message_overdue_by={time_since_start - next_message_time:.3f}s")
+                self._last_debug_log_time = time_since_start
+
+        released_count = 0
+        timeout_released_count = 0
+        
+        # Normal release: messages whose time has come
         while self.queue and self.queue[0].time <= time_since_start:
+            released_count += 1
             yield heapq.heappop(self.queue).as_tuple()
+            
+        # Safety timeout mechanism: if no messages have been released for too long,
+        # force-release the next few messages to prevent indefinite blocking
+        if self.queue and self._last_release_time is not None:
+            time_since_last_release = time_since_start - self._last_release_time
+            if time_since_last_release > self.timeout_sec:
+                import logging
+                logger = logging.getLogger(__name__)
+                logger.warning(f"RealtimeQueue timeout triggered! No messages released for {time_since_last_release:.1f}s (timeout={self.timeout_sec}s). Force-releasing next messages.")
+                
+                # Force-release up to 3 messages to prevent a complete freeze
+                max_timeout_release = min(3, len(self.queue))
+                for _ in range(max_timeout_release):
+                    if self.queue:
+                        timeout_released_count += 1
+                        item = heapq.heappop(self.queue)
+                        logger.warning(f"Timeout release: message scheduled for {item.time:.3f}s (current time_since_start={time_since_start:.3f}s)")
+                        yield item.as_tuple()
+        
+        # Update last release time
+        if released_count > 0 or timeout_released_count > 0:
+            self._last_release_time = time_since_start
+            
+        # Log if we released messages or if we have stuck messages
+        if released_count > 0 or timeout_released_count > 0 or (self.queue and self.queue[0].time <= time_since_start - 0.5):
+            import logging
+            logger = logging.getLogger(__name__)
+            if released_count > 0:
+                logger.info(f"RealtimeQueue: Released {released_count} messages normally, {len(self.queue)} remaining")
+            if timeout_released_count > 0:
+                logger.warning(f"RealtimeQueue: Force-released {timeout_released_count} messages due to timeout, {len(self.queue)} remaining")
+            if released_count == 0 and timeout_released_count == 0 and self.queue:
+                logger.warning(f"RealtimeQueue: No messages released, but {len(self.queue)} messages waiting (next due at {self.queue[0].time:.3f}s, current time_since_start={time_since_start:.3f}s)")
 
     async def __aiter__(self):
         if self.start_time is None or not self.queue:

--- a/unmute/tts/text_to_speech.py
+++ b/unmute/tts/text_to_speech.py
@@ -347,7 +347,9 @@ class TextToSpeech(ServiceWithStartup):
                     # has already been said, so that if there's an interruption, the
                     # chat history matches what's actually been said.
                     output_queue.put(message, message.stop_s)
-                    logger.info(f"Queued TTSTextMessage '{message.text}' with stop_s={message.stop_s}, queue size={len(output_queue.queue)}")
+                    current_time = output_queue.get_time() if output_queue.start_time else 0
+                    time_since_start = current_time - output_queue.start_time if output_queue.start_time else 0
+                    logger.info(f"Queued TTSTextMessage '{message.text}' with stop_s={message.stop_s}, current_time_since_start={time_since_start:.3f}, queue size={len(output_queue.queue)}")
 
                 for _, message in output_queue.get_nowait():
                     if isinstance(message, TTSAudioMessage):

--- a/unmute/unmute_handler.py
+++ b/unmute/unmute_handler.py
@@ -298,7 +298,18 @@ class UnmuteHandler(AsyncStreamHandler):
 
         This is so that we aren't tied to real-time streaming.
         """
-        return self.n_samples_received / self.input_sample_rate
+        current_audio_time = self.n_samples_received / self.input_sample_rate
+        
+        # Debug logging for timing diagnostics
+        if hasattr(self, '_last_audio_time_log'):
+            time_diff = current_audio_time - self._last_audio_time_log
+            if time_diff > 2.0:  # Log every 2 seconds of audio time
+                logger.info(f"Audio timing: n_samples_received={self.n_samples_received}, audio_received_sec={current_audio_time:.3f}, sample_rate={self.input_sample_rate}")
+                self._last_audio_time_log = current_audio_time
+        else:
+            self._last_audio_time_log = current_audio_time
+            
+        return current_audio_time
 
     async def receive(self, frame: tuple[int, np.ndarray]) -> None:
         stt = self.stt


### PR DESCRIPTION
## Checklist

- [ ] Read CONTRIBUTING.md, and accept the CLA by including the provided snippet. We will not accept PR without this.
```
I have read the CONTRIBUTING.md and I hereby accept the terms of the CLA.
```

## PR Description

This PR addresses the issue of Text-to-Speech (TTS) stopping speaking, particularly in scenarios where the `RealtimeQueue` gets stuck (e.g., the "Bonaparte" issue mentioned in `progress.md`).

The root cause was identified as the `audio_received_sec()` function potentially stopping its advancement, which in turn prevents messages from being released from the `RealtimeQueue`.

This PR implements a multi-layered solution:

1.  **Safety Timeout in `RealtimeQueue`**: Introduces a 5-second timeout mechanism to force-release stuck messages, preventing indefinite blocking and ensuring TTS continues.
2.  **Enhanced Diagnostics**: Adds comprehensive logging and timing diagnostics to `RealtimeQueue.get_nowait()`, `UnmuteHandler.audio_received_sec()`, and `TextToSpeech` message queuing. This provides crucial visibility into timing drift and stalls, aiding future debugging.

These changes ensure that the TTS system can gracefully handle timing anomalies, preventing complete speech cessation, while also providing the necessary tools to diagnose the underlying timing issues more precisely.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e638c12-cdcd-4af8-bed5-eabb05473a9d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5e638c12-cdcd-4af8-bed5-eabb05473a9d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

